### PR TITLE
Added <functional.h> include required for compilation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <vector>
 #include <string>
+#include <functional>
 
 #include <stdio.h>
 #include <dirent.h>


### PR DESCRIPTION
Without this, compilation fails on my 64-bit Linux machine with a "no member named 'function' in namespace 'std'" error, as std::function is declared in <functional.h>